### PR TITLE
add schema roles to link participants to schemas

### DIFF
--- a/src/__tests__/test.Governance.ts
+++ b/src/__tests__/test.Governance.ts
@@ -19,10 +19,14 @@ export const governance: GovernanceFile = {
     {
       id: "BXtzYPyPdiVKGAjkqtPexs:2:Email:1.0",
       name: "Email Credential Issuer",
+      issuer_roles: ["email_issuer"],
+      verifier_roles: ["email_verifier"],
     },
     {
       id: "QHqtjywxfP3yYsFrRHFLQm:2:Employment:1.0",
       name: "Employment Credential Issuer",
+      issuer_roles: ["employment_issuer"],
+      verifier_roles: ["employment_verifier"],
     },
   ],
   participants: {

--- a/src/types/Governance.ts
+++ b/src/types/Governance.ts
@@ -18,6 +18,8 @@ export interface GovernanceFile {
 export interface Schema {
   id: SchemaId;
   name: string;
+  issuer_roles?: string[];
+  verifier_roles?: string[];
 }
 
 export interface Participant {


### PR DESCRIPTION
Added roles to schemas to link participants to the schemas they can issue / verify according to documentation here : https://identity.foundation/credential-trust-establishment/#university-diploma-example